### PR TITLE
[지도] 백그라운드에서 사용자 위치 update 허용, 위치 접근 권한 거부 시 처리

### DIFF
--- a/Acha/Acha.xcodeproj/project.pbxproj
+++ b/Acha/Acha.xcodeproj/project.pbxproj
@@ -762,6 +762,9 @@
 				DEVELOPMENT_TEAM = WW8WYM6B54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Acha/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "허락해";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -791,6 +794,9 @@
 				DEVELOPMENT_TEAM = WW8WYM6B54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Acha/Info.plist;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "허락해";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/Acha/Acha.xcodeproj/project.pbxproj
+++ b/Acha/Acha.xcodeproj/project.pbxproj
@@ -832,7 +832,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Acha/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "허락해";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -864,7 +864,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Acha/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "허락해";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/Acha/Acha/Info.plist
+++ b/Acha/Acha/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string></string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -23,5 +19,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 </dict>
 </plist>

--- a/Acha/Acha/Presentation/Base/MapBaseViewController.swift
+++ b/Acha/Acha/Presentation/Base/MapBaseViewController.swift
@@ -13,6 +13,7 @@ import MapKit
 protocol MapBaseViewProtocol {
     var mapView: MKMapView { get set }
     var locationManager: CLLocationManager { get set }
+    var focusButton: UIButton { get set }
     
     func configureMapViewUI()
     func getLocationUsagePermission()
@@ -36,6 +37,16 @@ class MapBaseViewController: UIViewController, MapBaseViewProtocol {
         
         $0.showsBackgroundLocationIndicator = true
         $0.allowsBackgroundLocationUpdates = true
+    }
+    
+    lazy var focusButton = UIButton().then {
+        $0.setImage(SystemImageNameSpace.locationCircle.uiImage, for: .normal)
+        $0.tintColor = .pointLight
+        $0.addTarget(self, action: #selector(focusButtonDidClick), for: .touchDown)
+        
+        // button image size 설정
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 40)
+        $0.setPreferredSymbolConfiguration(imageConfig, forImageIn: .normal)
     }
     
     // MARK: - Lifecycles
@@ -65,6 +76,11 @@ class MapBaseViewController: UIViewController, MapBaseViewProtocol {
                                         span: MKCoordinateSpan(latitudeDelta: span, longitudeDelta: span))
         mapView.setRegion(region, animated: true)
     }
+    
+    @objc func focusButtonDidClick(_ sender: UIButton) {
+        focusUserLocation(useSpan: false)
+    }
+    
 }
 
 extension MapBaseViewController: CLLocationManagerDelegate {

--- a/Acha/Acha/Presentation/Base/MapBaseViewController.swift
+++ b/Acha/Acha/Presentation/Base/MapBaseViewController.swift
@@ -33,6 +33,9 @@ class MapBaseViewController: UIViewController, MapBaseViewProtocol {
         $0.desiredAccuracy = kCLLocationAccuracyBest
         $0.startUpdatingLocation()
         $0.delegate = self
+        
+        $0.showsBackgroundLocationIndicator = true
+        $0.allowsBackgroundLocationUpdates = true
     }
     
     // MARK: - Lifecycles
@@ -55,7 +58,6 @@ class MapBaseViewController: UIViewController, MapBaseViewProtocol {
             $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
-    
 }
 
 extension MapBaseViewController: CLLocationManagerDelegate {

--- a/Acha/Acha/Presentation/Base/MapBaseViewController.swift
+++ b/Acha/Acha/Presentation/Base/MapBaseViewController.swift
@@ -58,6 +58,13 @@ class MapBaseViewController: UIViewController, MapBaseViewProtocol {
             $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
+    
+    /// center 좌표에 span 0.01 수준으로 지도 포커스
+    func focusMapLocation(center: CLLocationCoordinate2D, span: Double = 0.01) {
+        let region = MKCoordinateRegion(center: center,
+                                        span: MKCoordinateSpan(latitudeDelta: span, longitudeDelta: span))
+        mapView.setRegion(region, animated: true)
+    }
 }
 
 extension MapBaseViewController: CLLocationManagerDelegate {
@@ -89,10 +96,7 @@ extension MapBaseViewController: CLLocationManagerDelegate {
         let center = CLLocationCoordinate2D(latitude: userLocation.coordinate.latitude,
                                             longitude: userLocation.coordinate.longitude)
         if useSpan {
-            /// 사용자 현위치에 폭 0.01 수준으로 지도 포커스
-            let region = MKCoordinateRegion(center: center,
-                                            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
-            mapView.setRegion(region, animated: true)
+            focusMapLocation(center: center)
         } else {
             mapView.setCenter(center, animated: true)
         }
@@ -104,7 +108,7 @@ extension MapBaseViewController: CLLocationManagerDelegate {
 
 extension MapBaseViewController: MKMapViewDelegate {
     
-    private func setUpMapView() {
+    func setUpMapView() {
         // 어플을 종료하고 다시 실행했을 때 MapKit이 발생할 수 있는 오류를 방지하기 위한 처리
         if #available(iOS 16.0, *) {
             mapView.preferredConfiguration = MKStandardMapConfiguration()

--- a/Acha/Acha/Presentation/Base/MapBaseViewController.swift
+++ b/Acha/Acha/Presentation/Base/MapBaseViewController.swift
@@ -66,8 +66,7 @@ class MapBaseViewController: UIViewController, MapBaseViewProtocol {
     func configureMapViewUI() {
         view.addSubview(mapView)
         mapView.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/Acha/Acha/Presentation/TabBar/Home/SelectMap/SelectMapViewController.swift
+++ b/Acha/Acha/Presentation/TabBar/Home/SelectMap/SelectMapViewController.swift
@@ -78,7 +78,7 @@ final class SelectMapViewController: MapBaseViewController {
         
         view.addSubview(focusButton)
         focusButton.snp.makeConstraints {
-            $0.top.equalTo(mapView.snp.top).offset(15)
+            $0.top.equalTo(mapView.snp.top).offset(50)
             $0.trailing.equalTo(mapView.snp.trailing).offset(-15)
             $0.width.height.equalTo(40)
         }

--- a/Acha/Acha/Presentation/TabBar/Home/SelectMap/SelectMapViewController.swift
+++ b/Acha/Acha/Presentation/TabBar/Home/SelectMap/SelectMapViewController.swift
@@ -121,14 +121,6 @@ final class SelectMapViewController: MapBaseViewController {
     @objc func focusButtonDidClick(_ sender: UIButton) {
         focusUserLocation(useSpan: false)
     }
-    
-    private func focusMapLocation(centerCoordinate: Coordinate) {
-        let center = CLLocationCoordinate2D(latitude: centerCoordinate.latitude - 0.003,
-                                              longitude: centerCoordinate.longitude)
-        let region = MKCoordinateRegion(center: center,
-                                        span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
-        mapView.setRegion(region, animated: true)
-    }
 }
 
 // MARK: - MKMapViewDelegate
@@ -146,7 +138,9 @@ extension SelectMapViewController {
         renderer?.strokeColor = .red
         
         // 땅이 랭킹뷰 위쪽에 오도록 지도 포커스
-        focusMapLocation(centerCoordinate: annotation.map.centerCoordinate)
+        let center = CLLocationCoordinate2D(latitude: annotation.map.centerCoordinate.latitude - 0.003,
+                                            longitude: annotation.map.centerCoordinate.longitude)
+        focusMapLocation(center: center)
     }
     
     func mapView(_ mapView: MKMapView, didDeselect annotation: MKAnnotation) {

--- a/Acha/Acha/Presentation/TabBar/Home/SelectMap/SelectMapViewController.swift
+++ b/Acha/Acha/Presentation/TabBar/Home/SelectMap/SelectMapViewController.swift
@@ -22,16 +22,6 @@ final class SelectMapViewController: MapBaseViewController {
         $0.font = UIFont.boldSystemFont(ofSize: 24)
     }
     
-    private lazy var focusButton = UIButton().then {
-        $0.setImage(SystemImageNameSpace.locationCircle.uiImage, for: .normal)
-        $0.tintColor = .pointLight
-        $0.addTarget(self, action: #selector(focusButtonDidClick), for: .touchDown)
-        
-        // button image size 설정
-        let imageConfig = UIImage.SymbolConfiguration(pointSize: 40)
-        $0.setPreferredSymbolConfiguration(imageConfig, forImageIn: .normal)
-    }
-    
     private lazy var startButton = UIButton().then {
         $0.setTitle("게임 시작", for: .normal)
         $0.tintColor = .white
@@ -116,10 +106,6 @@ final class SelectMapViewController: MapBaseViewController {
                     self?.mapView.addAnnotation(annotation)
                 }
             }).disposed(by: disposeBag)
-    }
-    
-    @objc func focusButtonDidClick(_ sender: UIButton) {
-        focusUserLocation(useSpan: false)
     }
 }
 


### PR DESCRIPTION
<!--
  더 나은 코드리뷰와 history 관리를 위해 아래 내용을 작성해 주세요.
-->

### 작업 내용:

- mapView(지도)의 오토레이아웃을 equalToSuperView에 맞춰줌에 따라 focus 버튼이 status bar에 가려지는 문제가 생겨서 focus 버튼의 오토레이아웃을 수정해주었습니다.

<img src="https://user-images.githubusercontent.com/68235938/202201257-74b9fc04-a65c-4ffe-a053-c34ab7f4c197.png" width="300" height="600"/>

- 앱이 백그라운드 상태가 되어도 user location을 업데이트 할 수 있도록 해주었습니다.

<img src="https://user-images.githubusercontent.com/68235938/202201549-cb192ed4-d0c2-47af-b787-fb11ac1289c8.png" width="300" height="600"/>

<img src="https://user-images.githubusercontent.com/68235938/202201561-0e6a4dbb-1897-4c4d-9f85-0b6acc6b3554.png" width="300" height="600"/>

- 모든 지도가 보여지는 화면에서 focus 버튼이 사용되기 때문에 focus 버튼을 MapBaseViewController에 추가해주었습니다.
- 사용자 위치 접근 권한이 거부되어 있다면 다음과 같이 alert 창을 띄워주어 설정창으로 이동할 수 있도록 해주었습니다.
    - 접근 권한 설정 후 다시 앱으로 돌아오면 정상적으로 동작

![RPReplay_Final1668606485](https://user-images.githubusercontent.com/68235938/202203466-300aa8d6-504b-482a-a5da-2c8de071946f.gif)

### 이번에 공들였던 부분:

<!--
  코드 리뷰에 참고할 만한 내용을 적어주세요.
  이번에 특정 부분들을 집중해서 작성하셨다면, 그 부분에 대해서 설명해주세요!
-->

- 사용자 위치 접근 권한을 설정하지 않고 사용자 위치에 접근하게 되면 `This method can cause UI unresponsiveness if invoked on the main thread. Instead, consider waiting for the "-locationManagerDidChangeAuthorization:" callback and checking "authorizationStatus" first.` 경고가 발생해서, 사용자 위치 접근 권한이 허용된 후에 setUpUserLocation() 메소드를 호출하여 사용자 위치에 접근할 수 있도록 해주었습니다.

### 질문:

<!--
  이번 작업을 하면서 가졌던 질문을 공유해주세요.
  어떤 질문이든지 좋습니다!
-->

### 제출 전 필수 확인 사항:

- [x] 빌드가 되는 코드인가요? <!-- 빌드가 되지 않는 코드는 절대 merge 될 수 없습니다. -->
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요? <!-- 버그가 발생하는걸 알면서 QA를 넘기는건 매우 무책임한 행동입니다. -->

closes #56 
closes #54 
