### PR TITLE
[뱃지] 이미지 로드 방식 수정 + [공통] 이미지 캐시 서비스

### DIFF
--- a/Acha/Acha.xcodeproj/project.pbxproj
+++ b/Acha/Acha.xcodeproj/project.pbxproj
@@ -95,6 +95,9 @@
 		76A2E1A12923C5A7001E887A /* SingleGameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A2E19F2923C5A7001E887A /* SingleGameViewModel.swift */; };
 		76A2E1A32923D94C001E887A /* CLLocationCoordinate2D+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A2E1A22923D94C001E887A /* CLLocationCoordinate2D+.swift */; };
 		76A2E1A529249099001E887A /* Double+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A2E1A429249099001E887A /* Double+.swift */; };
+		76A4320A2944B08800D5963F /* DefaultFirebaseStorageNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A432092944B08800D5963F /* DefaultFirebaseStorageNetworkService.swift */; };
+		76A4320C2944B16900D5963F /* FirebaseStorageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A4320B2944B16900D5963F /* FirebaseStorageType.swift */; };
+		76A4320E2944B1A600D5963F /* FirebaseStorageNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A4320D2944B1A600D5963F /* FirebaseStorageNetworkService.swift */; };
 		76AA55A42937760B00498441 /* BadgeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AA55A32937760B00498441 /* BadgeCell.swift */; };
 		76AA55A62937762800498441 /* BadgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AA55A52937762800498441 /* BadgeViewController.swift */; };
 		76AA55A82937765F00498441 /* BadgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AA55A72937765F00498441 /* BadgeViewModel.swift */; };
@@ -135,6 +138,8 @@
 		76B3BF52292624DB0056ABFD /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B3BF51292624DA0056ABFD /* Int+.swift */; };
 		76B3BF54292624E30056ABFD /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B3BF53292624E30056ABFD /* Date+.swift */; };
 		76B3BF56292627A30056ABFD /* GamePlayMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B3BF55292627A30056ABFD /* GamePlayMenuView.swift */; };
+		76CF82122945A73800B51B2E /* DefaultImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CF82112945A73800B51B2E /* DefaultImageCacheService.swift */; };
+		76CF82142945AB7100B51B2E /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CF82132945AB7100B51B2E /* ImageCacheService.swift */; };
 		E5027D5329263D620021BF60 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4738D765292238C3003AE835 /* UIColor+.swift */; };
 		E5027D5629265D910021BF60 /* SelectMapRecordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5027D5529265D910021BF60 /* SelectMapRecordCell.swift */; };
 		E5027D58292670570021BF60 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5027D57292670570021BF60 /* Record.swift */; };
@@ -341,6 +346,9 @@
 		76A2E19F2923C5A7001E887A /* SingleGameViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleGameViewModel.swift; sourceTree = "<group>"; };
 		76A2E1A22923D94C001E887A /* CLLocationCoordinate2D+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+.swift"; sourceTree = "<group>"; };
 		76A2E1A429249099001E887A /* Double+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+.swift"; sourceTree = "<group>"; };
+		76A432092944B08800D5963F /* DefaultFirebaseStorageNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFirebaseStorageNetworkService.swift; sourceTree = "<group>"; };
+		76A4320B2944B16900D5963F /* FirebaseStorageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseStorageType.swift; sourceTree = "<group>"; };
+		76A4320D2944B1A600D5963F /* FirebaseStorageNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseStorageNetworkService.swift; sourceTree = "<group>"; };
 		76AA55A1293775F200498441 /* MyPageHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageHeaderView.swift; sourceTree = "<group>"; };
 		76AA55A32937760B00498441 /* BadgeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeCell.swift; sourceTree = "<group>"; };
 		76AA55A52937762800498441 /* BadgeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeViewController.swift; sourceTree = "<group>"; };
@@ -383,6 +391,8 @@
 		76B3BF51292624DA0056ABFD /* Int+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		76B3BF53292624E30056ABFD /* Date+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		76B3BF55292627A30056ABFD /* GamePlayMenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GamePlayMenuView.swift; sourceTree = "<group>"; };
+		76CF82112945A73800B51B2E /* DefaultImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageCacheService.swift; sourceTree = "<group>"; };
+		76CF82132945AB7100B51B2E /* ImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheService.swift; sourceTree = "<group>"; };
 		E5027D5529265D910021BF60 /* SelectMapRecordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectMapRecordCell.swift; sourceTree = "<group>"; };
 		E5027D57292670570021BF60 /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		E5027D59292670BC0021BF60 /* RecordViewHeaderRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewHeaderRecord.swift; sourceTree = "<group>"; };
@@ -787,6 +797,8 @@
 				F1B514EA293B3FDD00F653F3 /* DefaultAuthService.swift */,
 				F1E7B0B0293DD1E80088332E /* DefaultRandomService.swift */,
 				766978C02940885D002128C7 /* DefaultImageService.swift */,
+				76A432092944B08800D5963F /* DefaultFirebaseStorageNetworkService.swift */,
+				76CF82112945A73800B51B2E /* DefaultImageCacheService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -802,6 +814,8 @@
 				F1B514E6293B3F6500F653F3 /* KeychainService.swift */,
 				F1B514EC293B3FEC00F653F3 /* AuthService.swift */,
 				F1E7B0B2293DD1F80088332E /* RandomService.swift */,
+				76A4320D2944B1A600D5963F /* FirebaseStorageNetworkService.swift */,
+				76CF82132945AB7100B51B2E /* ImageCacheService.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1204,6 +1218,7 @@
 				4738D767292267BA003AE835 /* Errors.swift */,
 				47935E942923310700481307 /* SystemImageNameSpace.swift */,
 				47D5774429338A040014D171 /* FirebaseRealtimeType.swift */,
+				76A4320B2944B16900D5963F /* FirebaseStorageType.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1534,6 +1549,7 @@
 				474E24FA293DC75F00CFAC59 /* DefaultRecordMainViewUseCase.swift in Sources */,
 				76AA55CE2937AC3500498441 /* UUIDGetable.swift in Sources */,
 				76AA55A82937765F00498441 /* BadgeViewModel.swift in Sources */,
+				76A4320E2944B1A600D5963F /* FirebaseStorageNetworkService.swift in Sources */,
 				F1FCEE11292B4C87001A55D6 /* AuthButton.swift in Sources */,
 				474E24E5293DC6B800CFAC59 /* RecordMainViewController.swift in Sources */,
 				76AA560F2937ADD400498441 /* AuthUseCaseProtocol.swift in Sources */,
@@ -1622,6 +1638,7 @@
 				F1CC514B293F237B00B9008D /* PlayerAnnotation.swift in Sources */,
 				47D57743293389EB0014D171 /* DefaultSelectMapUseCase.swift in Sources */,
 				F156F11A29235EC50053E807 /* ImageConstants.swift in Sources */,
+				76A4320A2944B08800D5963F /* DefaultFirebaseStorageNetworkService.swift in Sources */,
 				76AA55EA2937AD7A00498441 /* QRReaderViewController.swift in Sources */,
 				F1B514F1293B414F00F653F3 /* DefaultUserRepository.swift in Sources */,
 				47D577592934A9FE0014D171 /* MapBaseViewModel.swift in Sources */,
@@ -1631,6 +1648,7 @@
 				F1B514E3293B26C500F653F3 /* CommunityDTO.swift in Sources */,
 				F1CC513B293EE64700B9008D /* MultiGameRoomUseCase.swift in Sources */,
 				766978C12940885D002128C7 /* DefaultImageService.swift in Sources */,
+				76CF82142945AB7100B51B2E /* ImageCacheService.swift in Sources */,
 				474E24E6293DC6B800CFAC59 /* RecordMainHeaderView.swift in Sources */,
 				F1DED402293880CB00ABC047 /* DefaultCommunityRepository.swift in Sources */,
 				F1B514E3293B26C500F653F3 /* CommunityDTO.swift in Sources */,
@@ -1663,6 +1681,7 @@
 				47D5773B293389940014D171 /* MapRepository.swift in Sources */,
 				76B3BF54292624E30056ABFD /* Date+.swift in Sources */,
 				F1E83D7729348591004C7992 /* CommunityViewModel.swift in Sources */,
+				76A4320C2944B16900D5963F /* FirebaseStorageType.swift in Sources */,
 				F1DED3FE29386F7400ABC047 /* HealthKitReadData.swift in Sources */,
 				76AA55FF2937AD8900498441 /* GameRoomCollectionViewCell.swift in Sources */,
 				F1DED3A62935F0A400ABC047 /* CommentCollectionViewCell.swift in Sources */,
@@ -1719,6 +1738,7 @@
 				F1FCEE0E292B483E001A55D6 /* UITextField+.swift in Sources */,
 				474E24F7293DC73200CFAC59 /* TempDBNetwork.swift in Sources */,
 				474E24E4293DC6B800CFAC59 /* LineGraphView.swift in Sources */,
+				76CF82122945A73800B51B2E /* DefaultImageCacheService.swift in Sources */,
 				47D5774F29338A7A0014D171 /* DefaultRealtimeDatabaseNetworkService.swift in Sources */,
 				E5BE8B9929221A4C00E9CFE8 /* RecordCoordinator.swift in Sources */,
 				47D5773D293389AC0014D171 /* DefaultMapRepository.swift in Sources */,

--- a/Acha/Acha/Data/DTO/BadgeDTO.swift
+++ b/Acha/Acha/Data/DTO/BadgeDTO.swift
@@ -20,10 +20,10 @@ struct BadgeDTO: Codable {
         case isHidden
     }
     
-    func toDomain() -> Badge {
+    func toDomain(image: Data) -> Badge {
         Badge(id: id,
               name: name,
-              imageURL: imageURL,
+              image: image,
               isHidden: isHidden)
     }
 }

--- a/Acha/Acha/Data/Repository/DefaultBadgeRepository.swift
+++ b/Acha/Acha/Data/Repository/DefaultBadgeRepository.swift
@@ -6,22 +6,43 @@
 //
 
 import RxSwift
+import Foundation
 
 final class DefaultBadgeRepository: BadgeRepository {
     private let realTimeDatabaseNetworkService: RealtimeDatabaseNetworkService
+    private let firebaseStorageNetworkService: FirebaseStorageNetworkService
+    private let imageCacheService: ImageCacheService
+    private var disposeBag = DisposeBag()
     
-    init(realTimeDatabaseNetworkService: RealtimeDatabaseNetworkService) {
+    init(
+        realTimeDatabaseNetworkService: RealtimeDatabaseNetworkService,
+        firebaseStorageNetworkService: FirebaseStorageNetworkService,
+        imageCacheService: ImageCacheService
+    ) {
         self.realTimeDatabaseNetworkService = realTimeDatabaseNetworkService
+        self.firebaseStorageNetworkService = firebaseStorageNetworkService
+        self.imageCacheService = imageCacheService
     }
     
-    func fetchAllBadges() -> Single<[Badge]> {
+    func fetchAllBadges() -> Observable<[Badge]> {
         realTimeDatabaseNetworkService.fetch(type: FirebaseRealtimeType.badge)
-            .map { (badgeDTOs: [BadgeDTO]) in
-                badgeDTOs.map { $0.toDomain() }
+            .asObservable()
+            .flatMap { (badgeDTOs: [BadgeDTO]) in
+                Observable.zip(badgeDTOs.map { badgeDTO in
+                    if let data = self.imageCacheService.load(imageURL: badgeDTO.imageURL) {
+                        return Observable.of(badgeDTO.toDomain(image: data))
+                    }
+                    
+                    return self.firebaseStorageNetworkService.download(urlString: badgeDTO.imageURL)
+                        .map { data -> Badge in
+                            self.imageCacheService.write(imageURL: badgeDTO.imageURL, image: data)
+                            return badgeDTO.toDomain(image: data)
+                        }
+                })
             }
     }
     
-    func fetchSomeBadges(ids: [Int]) -> Single<[Badge]> {
+    func fetchSomeBadges(ids: [Int]) -> Observable<[Badge]> {
         fetchAllBadges()
             .map { (badges: [Badge]) -> [Badge] in
                 return badges.filter { ids.contains($0.id) }

--- a/Acha/Acha/Data/Repository/Protocol/BadgeRepository.swift
+++ b/Acha/Acha/Data/Repository/Protocol/BadgeRepository.swift
@@ -8,6 +8,6 @@
 import RxSwift
 
 protocol BadgeRepository {
-    func fetchAllBadges() -> Single<[Badge]>
-    func fetchSomeBadges(ids: [Int]) -> Single<[Badge]>
+    func fetchAllBadges() -> Observable<[Badge]>
+    func fetchSomeBadges(ids: [Int]) -> Observable<[Badge]>
 }

--- a/Acha/Acha/Domain/Entity/Badge.swift
+++ b/Acha/Acha/Domain/Entity/Badge.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Badge: Hashable {
     let id: Int
     let name: String
-    let imageURL: String
+    let image: Data
     let isHidden: Bool
     var isOwn: Bool = false
 }

--- a/Acha/Acha/Domain/UseCase/DefaultMyPageUseCase.swift
+++ b/Acha/Acha/Domain/UseCase/DefaultMyPageUseCase.swift
@@ -43,7 +43,7 @@ final class DefaultMyPageUseCase: MyPageUseCase {
                         self.allBadges.onNext(badges.map {
                             Badge(id: $0.id,
                                   name: $0.name,
-                                  imageURL: $0.imageURL,
+                                  image: $0.image,
                                   isHidden: $0.isHidden,
                                   isOwn: user.badges.contains($0.id) ? true : false
                             )

--- a/Acha/Acha/Presentation/TabBar/Coordinator/MyPageCoordinator.swift
+++ b/Acha/Acha/Presentation/TabBar/Coordinator/MyPageCoordinator.swift
@@ -30,13 +30,16 @@ final class MyPageCoordinator: MyPageCoordinatorProtocol {
     }
     
     func showMyPageViewController() {
-        let networkService = DefaultRealtimeDatabaseNetworkService()
+        let realtimeNetworkService = DefaultRealtimeDatabaseNetworkService()
+        let storageNetworkService = DefaultFirebaseStorageNetworkService()
         let keychainService = DefaultKeychainService()
         let authService = DefaultAuthService()
-        let userRepository = DefaultUserRepository(realtimeDataBaseService: networkService,
+        let userRepository = DefaultUserRepository(realtimeDataBaseService: realtimeNetworkService,
                                                    keychainService: keychainService,
                                                    authService: authService)
-        let badgeRepository = DefaultBadgeRepository(realTimeDatabaseNetworkService: networkService)
+        let badgeRepository = DefaultBadgeRepository(realTimeDatabaseNetworkService: realtimeNetworkService,
+                                                     firebaseStorageNetworkService: storageNetworkService,
+                                                     imageCacheService: DefaultImageCacheService())
         let useCase = DefaultMyPageUseCase(userRepository: userRepository, badgeRepository: badgeRepository)
         let viewModel = MyPageViewModel(coordinator: self, useCase: useCase)
         let viewController = MyPageViewController(viewModel: viewModel)

--- a/Acha/Acha/Presentation/TabBar/MyPage/View/BadgeCell.swift
+++ b/Acha/Acha/Presentation/TabBar/MyPage/View/BadgeCell.swift
@@ -51,8 +51,8 @@ final class BadgeCell: UICollectionViewCell {
         }
     }
     
-    func bind(badge: Badge, disposeBag: DisposeBag) {
-        badgeImage.setImage(url: badge.imageURL, disposeBag: disposeBag)
+    func bind(badge: Badge) {
+        badgeImage.image = UIImage(data: badge.image)
         badgeLabel.text = badge.name
     }
 }

--- a/Acha/Acha/Presentation/TabBar/MyPage/ViewController/BadgeViewController.swift
+++ b/Acha/Acha/Presentation/TabBar/MyPage/ViewController/BadgeViewController.swift
@@ -82,8 +82,7 @@ class BadgeViewController: UIViewController {
                 for: indexPath) as? BadgeCell else {
                 return BadgeCell()
             }
-            cell.bind(badge: item,
-                      disposeBag: self.disposeBag)
+            cell.bind(badge: item)
             return cell
         })
         configureHeaderDataSource()
@@ -115,9 +114,7 @@ class BadgeViewController: UIViewController {
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
                 heightDimension: .estimated(145))
-            let groupInsets = NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-            group.contentInsets = groupInsets
             
             let headerSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),

--- a/Acha/Acha/Presentation/TabBar/MyPage/ViewController/MyPageViewController.swift
+++ b/Acha/Acha/Presentation/TabBar/MyPage/ViewController/MyPageViewController.swift
@@ -234,8 +234,7 @@ extension MyPageViewController {
                     for: indexPath) as? BadgeCell else {
                     return BadgeCell()
                 }
-                    cell.bind(badge: badge,
-                              disposeBag: self.disposeBag)
+                    cell.bind(badge: badge)
                 return cell
             case .setting(let type):
                 guard let cell = collectionView.dequeueReusableCell(

--- a/Acha/Acha/Util/Enums/FirebaseStorageType.swift
+++ b/Acha/Acha/Util/Enums/FirebaseStorageType.swift
@@ -1,0 +1,8 @@
+//
+//  FirebaseStorageType.swift
+//  Acha
+//
+//  Created by 조승기 on 2022/12/10.
+//
+
+import Foundation

--- a/Acha/Acha/Util/Enums/FirebaseStorageType.swift
+++ b/Acha/Acha/Util/Enums/FirebaseStorageType.swift
@@ -2,7 +2,27 @@
 //  FirebaseStorageType.swift
 //  Acha
 //
-//  Created by 조승기 on 2022/12/10.
+//  Created by 배남석 on 2022/12/07.
 //
 
 import Foundation
+
+enum FirebaseStorageType {
+    case map
+    case category(String)
+    case badge
+    case pinCharacter
+    
+    var path: String {
+        switch self {
+        case .map:
+            return "Map"
+        case .category(let name):
+            return "Category/\(name)"
+        case .badge:
+            return "Badge"
+        case .pinCharacter:
+            return "PinCharacter"
+        }
+    }
+}

--- a/Acha/Acha/Util/Service/DefaultFirebaseStorageNetworkService.swift
+++ b/Acha/Acha/Util/Service/DefaultFirebaseStorageNetworkService.swift
@@ -67,4 +67,24 @@ final class DefaultFirebaseStorageNetworkService: FirebaseStorageNetworkService 
         }.resume()
     }
     
+    private var disposeBag = DisposeBag()
+    func download(urlString: String) -> Observable<Data> {
+        return Observable<Data>.create { [weak self] observer in
+            guard let self,
+                  let url = URL(string: urlString) else {
+                observer.onError(FirebaseStorageError.urlError)
+                return Disposables.create()
+            }
+            
+            URLSession.shared.rx.data(request: URLRequest(url: url))
+                .subscribe(onNext: { data in
+                    observer.onNext(data)
+                }, onError: { error in
+                    observer.onError(error)
+                })
+                .disposed(by: self.disposeBag)
+
+            return Disposables.create()
+        }
+    }
 }

--- a/Acha/Acha/Util/Service/DefaultFirebaseStorageNetworkService.swift
+++ b/Acha/Acha/Util/Service/DefaultFirebaseStorageNetworkService.swift
@@ -2,7 +2,69 @@
 //  DefaultFirebaseStorageNetworkService.swift
 //  Acha
 //
-//  Created by 조승기 on 2022/12/10.
+//  Created by 배남석 on 2022/12/07.
 //
 
+import RxSwift
+import FirebaseStorage
 import Foundation
+
+final class DefaultFirebaseStorageNetworkService: FirebaseStorageNetworkService {
+    private let storage = Storage.storage()
+    
+    enum FirebaseStorageError: Error {
+        case dataError
+        case decodeError
+        case encodeError
+        case urlError
+    }
+    
+    func upload(type: FirebaseStorageType, data: Data) -> Single<URL> {
+        return Single.create { [weak self] single in
+            guard let self else { return Disposables.create() }
+            let metaData = StorageMetadata()
+            metaData.contentType = "image/jpeg"
+            
+            let firebaseReference = self.storage.reference().child(type.path)
+            firebaseReference.putData(data, metadata: metaData) { metaData, error in
+                firebaseReference.downloadURL { url, _ in
+                    if let url {
+                        single(.success(url))
+                    } else {
+                        single(.failure(error!))
+                    }
+                }
+            }
+            
+            return Disposables.create()
+        }
+    }
+    
+    func upload(type: FirebaseStorageType, data: Data, completion: @escaping (URL?) -> Void) {
+        let metaData = StorageMetadata()
+        metaData.contentType = "image/jpeg"
+        
+        let firebaseReference = Storage.storage().reference().child(type.path)
+        firebaseReference.putData(data, metadata: metaData) { _ , _ in
+            firebaseReference.downloadURL { url, _ in
+                completion(url)
+            }
+        }
+    }
+    
+    func download(urlString: String, completion: @escaping (Data?) -> Void) {
+        guard let url = URL(string: urlString) else { return }
+        
+        URLSession.shared.dataTask(with: url) { (data, response, _) in
+            guard let data = data,
+                  let response = response as? HTTPURLResponse,
+                  response.statusCode == 200 else {
+                completion(nil)
+                return
+            }
+            
+            completion(data)
+        }.resume()
+    }
+    
+}

--- a/Acha/Acha/Util/Service/DefaultFirebaseStorageNetworkService.swift
+++ b/Acha/Acha/Util/Service/DefaultFirebaseStorageNetworkService.swift
@@ -1,0 +1,8 @@
+//
+//  DefaultFirebaseStorageNetworkService.swift
+//  Acha
+//
+//  Created by 조승기 on 2022/12/10.
+//
+
+import Foundation

--- a/Acha/Acha/Util/Service/DefaultImageCacheService.swift
+++ b/Acha/Acha/Util/Service/DefaultImageCacheService.swift
@@ -28,12 +28,10 @@ struct DefaultImageCacheService: ImageCacheService {
         guard let url = URL(string: imageURL) else { return nil }
 
         if let data = memoryCache.load(imageURL: url) {
-            print("MemoryCache hit")
             return data
         }
         
         if let data = diskCache.load(imageURL: url) {
-            print("DiskCache hit")
             memoryCache.write(imageURL: url, data: data)
             return data
         }
@@ -132,7 +130,6 @@ struct DiskCache {
                                                                       includingPropertiesForKeys: [.fileSizeKey]) else {
             return 0
         }
-        
         return resourceKeys.reduce(0) { result, url in
             guard let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize else {
                 return result

--- a/Acha/Acha/Util/Service/DefaultImageCacheService.swift
+++ b/Acha/Acha/Util/Service/DefaultImageCacheService.swift
@@ -84,11 +84,13 @@ struct DiskCache {
         let path = pathURL.appendingPathComponent(imageURL.lastPathComponent)
         guard let data else { return }
         
-        if cacheSize > maxCacheSize {
+        if cacheSize + data.count > maxCacheSize {
             removeCache(needSize: data.count)
         }
         
-        fileManager.createFile(atPath: path.path, contents: data, attributes: nil)
+        // contentModificationDateKey을 현재로 설정하면서, 파일을 생성
+        let attributes: [FileAttributeKey: Any] = [.modificationDate: Date()]
+        fileManager.createFile(atPath: path.path, contents: data, attributes: attributes)
     }
     
     /// contentModificationDateKey 기준으로, 필요한 만큼만 삭제

--- a/Acha/Acha/Util/Service/DefaultImageCacheService.swift
+++ b/Acha/Acha/Util/Service/DefaultImageCacheService.swift
@@ -1,0 +1,158 @@
+//
+//  DefaultImageCacheService.swift
+//  Acha
+//
+//  Created by 조승기 on 2022/12/11.
+//
+
+import Foundation
+
+struct DefaultImageCacheService: ImageCacheService {
+    private let diskCache = DiskCache()
+    private let memoryCache = MemoryCache.shared
+    
+    enum ImageCacheError: Error {
+        case urlError
+        case dataError
+        case dataLoadError
+        case unknownError
+    }
+    
+    /// 필요할까요
+    private func isExist(imageURL: String) -> Bool {
+        guard let url = URL(string: imageURL) else { return false }
+        return memoryCache.load(imageURL: url) != nil || diskCache.isExist(imageURL: url)
+    }
+    
+    func load(imageURL: String) -> Data? {
+        guard let url = URL(string: imageURL) else { return nil }
+
+        if let data = memoryCache.load(imageURL: url) {
+            print("MemoryCache hit")
+            return data
+        }
+        
+        if let data = diskCache.load(imageURL: url) {
+            print("DiskCache hit")
+            memoryCache.write(imageURL: url, data: data)
+            return data
+        }
+        
+        return nil
+    }
+    
+    func write(imageURL: String, image: Data) {
+        guard let url = URL(string: imageURL) else { return }
+        memoryCache.write(imageURL: url, data: image)
+        diskCache.write(imageURL: url, data: image)
+    }
+}
+
+struct DiskCache {
+    private let pathURL: URL
+    private let fileManager = FileManager.default
+    var cacheSize: Int {
+        directorySize(url: pathURL)
+    }
+    var maxCacheSize: Int {
+        1024*1024*50
+    }
+    
+    init() {
+        let directory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        pathURL = directory.appendingPathComponent("ImageCache")
+        if !fileManager.fileExists(atPath: pathURL.path) {
+            try? fileManager.createDirectory(at: pathURL, withIntermediateDirectories: true, attributes: nil)
+        }
+    }
+    
+    func isExist(imageURL: URL) -> Bool {
+        let path = pathURL.appendingPathComponent(imageURL.lastPathComponent)
+        return fileManager.fileExists(atPath: path.path)
+    }
+    
+    func load(imageURL: URL) -> Data? {
+        let path = pathURL.appendingPathComponent(imageURL.lastPathComponent)
+        guard let data = try? Data(contentsOf: path) else { return nil }
+        
+        try? fileManager.setAttributes([FileAttributeKey.modificationDate: Date()], ofItemAtPath: path.path)
+        
+        return data
+    }
+    
+    func write(imageURL: URL, data: Data?) {
+        let path = pathURL.appendingPathComponent(imageURL.lastPathComponent)
+        guard let data else { return }
+        
+        if cacheSize > maxCacheSize {
+            removeCache(needSize: data.count)
+        }
+        
+        fileManager.createFile(atPath: path.path, contents: data, attributes: nil)
+    }
+    
+    /// contentModificationDateKey 기준으로, 필요한 만큼만 삭제
+    private func removeCache(needSize: Int) {
+        let propertyKeys: [URLResourceKey] = [.fileSizeKey, .contentModificationDateKey]
+        guard let resourceKeys = try? fileManager.contentsOfDirectory(at: pathURL,
+                                                                      includingPropertiesForKeys: propertyKeys)
+        else {
+            return
+        }
+        
+        let sortedResourceKeys = resourceKeys.sorted { url1, url2 in
+            guard let date1 = try? url1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate,
+                  let date2 = try? url2.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+            else {
+                return false
+            }
+            return date1 < date2
+        }
+        
+        var removedSize = 0
+        for url in sortedResourceKeys {
+            guard let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize else {
+                continue
+            }
+            
+            try? fileManager.removeItem(at: url)
+            removedSize += fileSize
+            
+            if removedSize >= needSize {
+                break
+            }
+        }
+    }
+    
+    /// fileSizeKey 를 이용해서, 디렉토리 내 파일들의 총 크기를 구함
+    private func directorySize(url: URL) -> Int {
+        guard let resourceKeys = try? fileManager.contentsOfDirectory(at: url,
+                                                                      includingPropertiesForKeys: [.fileSizeKey]) else {
+            return 0
+        }
+        
+        return resourceKeys.reduce(0) { result, url in
+            guard let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize else {
+                return result
+            }
+            return result + fileSize
+        }
+    }
+}
+
+struct MemoryCache {
+    let cache = NSCache<AnyObject, AnyObject>()
+    static let shared = MemoryCache(capacity: 1024*1024*50)
+    
+    init(capacity: Int) {
+        cache.totalCostLimit = capacity
+    }
+    
+    func load(imageURL: URL) -> Data? {
+        cache.object(forKey: imageURL.lastPathComponent as AnyObject) as? Data
+    }
+    
+    func write(imageURL: URL, data: Data?) {
+        cache.setObject(data as AnyObject, forKey: imageURL.lastPathComponent as AnyObject)
+    }
+}

--- a/Acha/Acha/Util/Service/Protocol/FirebaseStorageNetworkService.swift
+++ b/Acha/Acha/Util/Service/Protocol/FirebaseStorageNetworkService.swift
@@ -11,4 +11,5 @@ import RxSwift
 protocol FirebaseStorageNetworkService {
     func upload(type: FirebaseStorageType, data: Data, completion: @escaping (URL?) -> Void)
     func download(urlString: String, completion: @escaping (Data?) -> Void)
+    func download(urlString: String) -> Observable<Data>
 }

--- a/Acha/Acha/Util/Service/Protocol/FirebaseStorageNetworkService.swift
+++ b/Acha/Acha/Util/Service/Protocol/FirebaseStorageNetworkService.swift
@@ -2,7 +2,13 @@
 //  FirebaseStorageNetworkService.swift
 //  Acha
 //
-//  Created by 조승기 on 2022/12/10.
+//  Created by 배남석 on 2022/12/07.
 //
 
 import Foundation
+import RxSwift
+
+protocol FirebaseStorageNetworkService {
+    func upload(type: FirebaseStorageType, data: Data, completion: @escaping (URL?) -> Void)
+    func download(urlString: String, completion: @escaping (Data?) -> Void)
+}

--- a/Acha/Acha/Util/Service/Protocol/FirebaseStorageNetworkService.swift
+++ b/Acha/Acha/Util/Service/Protocol/FirebaseStorageNetworkService.swift
@@ -1,0 +1,8 @@
+//
+//  FirebaseStorageNetworkService.swift
+//  Acha
+//
+//  Created by 조승기 on 2022/12/10.
+//
+
+import Foundation

--- a/Acha/Acha/Util/Service/Protocol/ImageCacheService.swift
+++ b/Acha/Acha/Util/Service/Protocol/ImageCacheService.swift
@@ -1,0 +1,8 @@
+//
+//  ImageCacheService.swift
+//  Acha
+//
+//  Created by 조승기 on 2022/12/11.
+//
+
+import Foundation

--- a/Acha/Acha/Util/Service/Protocol/ImageCacheService.swift
+++ b/Acha/Acha/Util/Service/Protocol/ImageCacheService.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+protocol ImageCacheService {
+    func load(imageURL: String) -> Data?
+    func write(imageURL: String, image: Data)
+}

--- a/AchaLibrary/Package.swift
+++ b/AchaLibrary/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
                 .product(name: "FirebaseDatabase", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
+                .product(name: "FirebaseStorage", package: "firebase-ios-sdk"),
                 .product(name: "RxCocoa", package: "RxSwift"),
                 .product(name: "RxRelay", package: "RxSwift"),
                 .product(name: "RxSwift", package: "RxSwift"),


### PR DESCRIPTION
### 작업 내용:
- 뱃지 이미지 방식 변경
  - 기존: imageURL로 받아온 뱃지를, DefaultImageService 를 통해 사용할 때 뱃지 이미지로 변경
  - 변경: Repository 에서 DTO toDomain 시, 뱃지 이미지를 뱃지 이미지로 변경

- 이미지 캐시 서비스
  - 기존: 구닥다리 싱글턴 ImageService 에서 캐시를 관리
  - 변경: ImageCacheService 를 통해 캐시 관리
  - [노선 셜명](https://www.notion.so/seungki-cho/8094f36002254577983deea843148042)

### 이번에 공들였던 부분:
- 이미지 캐시 서비스 (디스크 캐시)

### 질문:
- 이미지 캐시 서비스에 대한 피드백
- 용량 정책
  - 현재는 디스크캐시와 메모리캐시 모두 1024*1024*50바이트 (50MB) 로 설정되어 있습니다.
- 뱃지 이미지 서버 저장 방식
  - 뱃지 추가 등 이미지 변경이 발생할 때마다, 서버에 이미지를 업로드하고, 이미지 URL 을 DB 에 저장하는 방식
  - 뱃지를 앱에 추가할 수도 있지만 변경에 용이한 방식을 선택했습니다.

### 제출 전 필수 확인 사항:

- [x] 빌드가 되는 코드인가요? <!-- 빌드가 되지 않는 코드는 절대 merge 될 수 없습니다. -->
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요? <!-- 버그가 발생하는걸 알면서 QA를 넘기는건 매우 무책임한 행동입니다. -->
