### PR TITLE
[홈] 홈 화면 UI 수정

### DIFF
--- a/Acha/Acha/Presentation/TabBar/Coordinator/HomeCoordinator.swift
+++ b/Acha/Acha/Presentation/TabBar/Coordinator/HomeCoordinator.swift
@@ -69,6 +69,7 @@ extension HomeCoordinator: CoordinatorDelegate {
         navigationController.viewControllers.last?.dismiss(animated: true)
         removeChildCoordinator(coordinator: childCoordinator)
         navigationController.viewControllers.removeAll(where: { !($0 is HomeViewController) })
+        navigationController.navigationBar.isHidden = false
         tabBarController?.tabBar.isHidden = false
     }
 }

--- a/Acha/Acha/Presentation/TabBar/Home/HomeView/ViewController/HomeViewController.swift
+++ b/Acha/Acha/Presentation/TabBar/Home/HomeView/ViewController/HomeViewController.swift
@@ -109,12 +109,10 @@ final class HomeViewController: UIViewController, UIViewControllerTransitioningD
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupSubviews()
         configureUI()
         bind()
-            
     }
-//
+
     private func bind() {
         let inputs = HomeViewModel.Input(
             singleGameModeDidTap: startSingleGameButton.rx.tap.asObservable(),
@@ -149,54 +147,36 @@ final class HomeViewController: UIViewController, UIViewControllerTransitioningD
     
     private func configureUI() {
         view.backgroundColor = .white
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.largeTitleDisplayMode = .automatic
-        navigationItem.title = "땅따먹기"
-        navigationController?.navigationBar.largeTitleTextAttributes = [
-            .foregroundColor: UIColor.pointLight
-        ]
-        navigationController?.navigationBar.shadowImage = UIImage()
+        configureNavigationBar()
         
+        view.addSubview(startGameContentView)
+        view.addSubview(titleLabel)
         startGameContentView.addSubview(singleGameShadowView)
         singleGameShadowView.addSubview(singleGameImageView)
         startGameContentView.addSubview(startSingleGameButton)
-        
         startGameContentView.addSubview(multiGameShadowView)
         multiGameShadowView.addSubview(multiGameImageView)
         startGameContentView.addSubview(startMultiGameButton)
 
-        startGameContentView.snp.makeConstraints {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(30)
             $0.leading.trailing.equalToSuperview().inset(15)
-            $0.height.equalTo(400)
-            $0.top.equalTo(titleLabel.snp.bottom).offset(-100)
+            $0.height.equalTo(80)
         }
         
-        titleLabel.snp.makeConstraints {
-            $0.height.equalTo(100)
-            $0.leading.trailing.equalToSuperview().inset(15)
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(50)
+        startGameContentView.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(titleLabel)
+            $0.height.equalTo(380)
         }
         
         singleGameShadowView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20)
             $0.leading.equalToSuperview().offset(10)
-            $0.top.equalToSuperview().offset(120)
+            $0.trailing.equalTo(view.snp.centerX).offset(-5)
             $0.bottom.equalToSuperview().offset(-20)
-            $0.width.equalTo(166)
         }
         
         singleGameImageView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
-        multiGameShadowView.snp.makeConstraints {
-            
-            $0.trailing.equalToSuperview().offset(-10)
-            $0.top.equalToSuperview().offset(120)
-            $0.bottom.equalToSuperview().offset(-20)
-            $0.width.equalTo(166)
-        }
-        
-        multiGameImageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
         
@@ -206,23 +186,30 @@ final class HomeViewController: UIViewController, UIViewControllerTransitioningD
             $0.height.equalTo(100)
         }
         
+        multiGameShadowView.snp.makeConstraints {
+            $0.top.bottom.equalTo(singleGameShadowView)
+            $0.leading.equalTo(view.snp.centerX).offset(5)
+            $0.trailing.equalToSuperview().offset(-10)
+        }
+        
+        multiGameImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
         startMultiGameButton.snp.makeConstraints {
             $0.center.equalTo(multiGameImageView)
             $0.leading.trailing.equalTo(multiGameImageView).inset(15)
-            $0.height.equalTo(100)
+            $0.height.equalTo(startSingleGameButton)
         }
     }
     
-    private func setupSubviews() {
-        view.addSubview(startGameContentView)
-        view.addSubview(titleLabel)
-        
-        startGameContentView.addSubview(singleGameShadowView)
-        singleGameShadowView.addSubview(singleGameImageView)
-        startGameContentView.addSubview(startSingleGameButton)
-        
-        startGameContentView.addSubview(multiGameShadowView)
-        multiGameShadowView.addSubview(multiGameImageView)
-        startGameContentView.addSubview(startMultiGameButton)
+    private func configureNavigationBar() {
+        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.largeTitleDisplayMode = .automatic
+        navigationItem.title = "땅따먹기"
+        navigationController?.navigationBar.largeTitleTextAttributes = [
+            .foregroundColor: UIColor.pointLight
+        ]
+        navigationController?.navigationBar.shadowImage = UIImage()
     }
 }


### PR DESCRIPTION
<!--
  더 나은 코드리뷰와 history 관리를 위해 아래 내용을 작성해 주세요.
-->

### 작업 내용:

### home UI
- SE에서 [혼자하기] 버튼과 [같이하기] 버튼이 겹치는 현상이 있어서 오토레이아웃 수정했습니다
- 수정 전
<img width="385" alt="home수정전" src="https://user-images.githubusercontent.com/68235938/207044228-9c1f75bc-5b74-479e-87a0-795bbf655920.png">

- 수정 후
<img width="388" alt="image" src="https://user-images.githubusercontent.com/68235938/207044207-2aaba265-cff5-48a2-ad25-631dfb4532da.png">

### navigation bar
- 땅 선택 화면 갔다가 돌아오면 홈 화면의 navigation bar가 사라지는 현상도 수정했습니다.

### 이번에 공들였던 부분:

<!--
  코드 리뷰에 참고할 만한 내용을 적어주세요.
  이번에 특정 부분들을 집중해서 작성하셨다면, 그 부분에 대해서 설명해주세요!
-->

### 질문:

<!--
  이번 작업을 하면서 가졌던 질문을 공유해주세요.
  어떤 질문이든지 좋습니다!
-->

### 제출 전 필수 확인 사항:

- [x] 빌드가 되는 코드인가요? <!-- 빌드가 되지 않는 코드는 절대 merge 될 수 없습니다. -->
- [x] 버그가 발생하지 않는지 충분히 테스트 해봤나요? <!-- 버그가 발생하는걸 알면서 QA를 넘기는건 매우 무책임한 행동입니다. -->
